### PR TITLE
remove the link to MVCAC from NJ dropdown

### DIFF
--- a/index.md
+++ b/index.md
@@ -129,9 +129,7 @@
                 <li>
                     <a href="https://vectorbio.rutgers.edu/reports/mosquito/" target="_blank">New Jersey Adult Mosquito Surveillance Reports</a>
                 </li>
-                <li>
-                    <a href="https://www.mvcac.org/" target="_blank">Mosquito and Vector Control Association of California</a>
-                </li>
+      
                 </p>
             </details>
             <details>


### PR DESCRIPTION
quick PR to remove a link to MVCAC from the New Jersey section

still some css tweaks to be made around bullet point alignment