### PR TITLE
Remove polyfill script and update to new mathjax version

### DIFF
--- a/_layouts/defaultdocs.html
+++ b/_layouts/defaultdocs.html
@@ -1,36 +1,40 @@
-<!DOCTYPE html>
-<html lang="{{ site.lang | default: "en-US" }}">
+<!doctype html>
+<html lang="{{ site.lang | default: 'en-US' }}">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,maximum-scale=2" />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      media="screen"
+      href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}"
+    />
+    <title>{{ site.title }} - {{ site.description }}</title>
+    <link rel="shortcut icon" href="/favicon3.ico" />
+    <script
+      id="MathJax-script"
+      defer
+      src="https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js"
+    ></script>
+  </head>
 
-<head>
-	<meta charset='utf-8'>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width,maximum-scale=2">
-	<link rel="stylesheet" type="text/css" media="screen" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
-	<title>{{ site.title }} - {{ site.description }}</title>
-	<link rel="shortcut icon" href="/favicon3.ico">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-  <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
-</head>
+  <body>
+    <div>
+      {% include header.html %}
 
-<body>
-
-  <div>
-    {% include header.html %}
-
-    <!-- MAIN CONTENT -->
-    <div class="main">
-      <div class="inner3"> 
-        <div class="inner2"> 
-          <!-- <div class="wrap-outer"> -->
-            <div class="wrap-inner">
-            {{ content }}
-            </div>
-          <!-- </div> -->
+      <!-- MAIN CONTENT -->
+      <div class="main">
+        <div class="inner3">
+          <div class="inner2">
+            <!-- <div class="wrap-outer"> -->
+            <div class="wrap-inner">{{ content }}</div>
+            <!-- </div> -->
+          </div>
         </div>
+        {% include footer.html %}
       </div>
-          {% include footer.html %}
     </div>
-  </div>
-  <script src="/assets/js/script.js"></script>
-</body>
+    <script src="/assets/js/script.js"></script>
+  </body>
 </html>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -3,11 +3,10 @@ layout: defaultdocs
 ---
 
 <head>
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
   <script
     id="MathJax-script"
-    async
-    src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
+    defer
+    src="https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js"
   ></script>
 </head>
 


### PR DESCRIPTION
- Remove third-party polyfill.io script tag, which is compromised
- Update mathjax script to newer version 4, which does not ask for polyfill
- prettify